### PR TITLE
Add simple pygame-based renderer

### DIFF
--- a/Test.py
+++ b/Test.py
@@ -1,1 +1,9 @@
-print("allo")
+from engine import Game, Entity
+
+if __name__ == "__main__":
+    game = Game(10, 10)
+    player = Entity(5, 5, "@")
+    game.add_entity(player)
+    # Run with a Pygame window until it is closed
+    game.run(steps=None)
+

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,8 @@
+"""Basic components for a tile-based simulation game engine."""
+
+from .world import World, Tile
+from .entity import Entity
+from .game import Game
+from .renderer import Renderer
+
+__all__ = ["World", "Tile", "Entity", "Game", "Renderer"]

--- a/engine/entity.py
+++ b/engine/entity.py
@@ -1,0 +1,17 @@
+"""Base entity classes used in the game engine."""
+
+from dataclasses import dataclass
+
+@dataclass
+class Entity:
+    x: int
+    y: int
+    char: str = "@"
+
+    def move(self, dx: int, dy: int, world) -> None:
+        """Move the entity by the given delta if the target tile is walkable."""
+        nx, ny = self.x + dx, self.y + dy
+        if 0 <= nx < world.width and 0 <= ny < world.height:
+            tile = world.get_tile(nx, ny)
+            if tile.walkable:
+                self.x, self.y = nx, ny

--- a/engine/game.py
+++ b/engine/game.py
@@ -1,0 +1,75 @@
+"""Minimal game engine loop and management."""
+
+from typing import List, Optional
+
+import pygame
+
+from .world import World
+from .entity import Entity
+from .renderer import Renderer
+
+
+class Game:
+    """A very small game engine managing the world and entities."""
+
+    def __init__(self, width: int = 10, height: int = 10) -> None:
+        self.world = World(width, height)
+        self.entities: List[Entity] = []
+        self.running = False
+
+    def add_entity(self, entity: Entity) -> None:
+        self.entities.append(entity)
+
+    def step(self) -> None:
+        """Advance the simulation by one tick."""
+        for entity in self.entities:
+            # For now, entities do nothing in each step.
+            pass
+
+    def run(self, steps: Optional[int] = 1) -> None:
+        """Run the game loop.
+
+        If ``steps`` is ``None``, run with a Pygame window until quit.
+        Otherwise, advance the simulation for the given number of steps.
+        """
+        self.running = True
+
+        if steps is None:
+            renderer = Renderer(self.world, self.entities)
+            clock = pygame.time.Clock()
+            while self.running:
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        self.stop()
+                    elif event.type == pygame.KEYDOWN:
+                        if event.key == pygame.K_ESCAPE:
+                            self.stop()
+                        self._handle_movement(event)
+
+                self.step()
+                renderer.render()
+                clock.tick(60)
+            renderer.shutdown()
+            return
+
+        for _ in range(steps):
+            if not self.running:
+                break
+            self.step()
+
+    def stop(self) -> None:
+        self.running = False
+
+    def _handle_movement(self, event: pygame.event.Event) -> None:
+        """Handle arrow key movement for the first entity, if any."""
+        if not self.entities:
+            return
+        player = self.entities[0]
+        if event.key == pygame.K_UP:
+            player.move(0, -1, self.world)
+        elif event.key == pygame.K_DOWN:
+            player.move(0, 1, self.world)
+        elif event.key == pygame.K_LEFT:
+            player.move(-1, 0, self.world)
+        elif event.key == pygame.K_RIGHT:
+            player.move(1, 0, self.world)

--- a/engine/renderer.py
+++ b/engine/renderer.py
@@ -1,0 +1,45 @@
+"""Simple Pygame renderer for the tile-based engine."""
+
+from __future__ import annotations
+
+import pygame
+
+from .world import World
+from .entity import Entity
+
+TILE_SIZE = 32
+
+class Renderer:
+    """Handles drawing of the world and entities using Pygame."""
+
+    def __init__(self, world: World, entities: list[Entity]) -> None:
+        self.world = world
+        self.entities = entities
+        pygame.init()
+        self.screen = pygame.display.set_mode(
+            (world.width * TILE_SIZE, world.height * TILE_SIZE)
+        )
+        pygame.display.set_caption("Game")
+        self.font = pygame.font.SysFont(None, 24)
+
+    def draw_world(self) -> None:
+        for y in range(self.world.height):
+            for x in range(self.world.width):
+                tile = self.world.get_tile(x, y)
+                color = (200, 200, 200) if tile.walkable else (100, 100, 100)
+                rect = pygame.Rect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE)
+                pygame.draw.rect(self.screen, color, rect)
+
+    def draw_entities(self) -> None:
+        for entity in self.entities:
+            text = self.font.render(entity.char, True, (0, 0, 0))
+            self.screen.blit(text, (entity.x * TILE_SIZE, entity.y * TILE_SIZE))
+
+    def render(self) -> None:
+        self.screen.fill((0, 0, 0))
+        self.draw_world()
+        self.draw_entities()
+        pygame.display.flip()
+
+    def shutdown(self) -> None:
+        pygame.quit()

--- a/engine/world.py
+++ b/engine/world.py
@@ -1,0 +1,25 @@
+"""World and Tile classes for the game engine."""
+
+from dataclasses import dataclass, field
+
+@dataclass
+class Tile:
+    """Represents a single tile in the world grid."""
+    name: str = "empty"
+    walkable: bool = True
+
+@dataclass
+class World:
+    """A simple 2D grid world made of tiles."""
+    width: int
+    height: int
+    tiles: list = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.tiles = [[Tile() for _ in range(self.width)] for _ in range(self.height)]
+
+    def get_tile(self, x: int, y: int) -> Tile:
+        return self.tiles[y][x]
+
+    def set_tile(self, x: int, y: int, tile: Tile) -> None:
+        self.tiles[y][x] = tile


### PR DESCRIPTION
## Summary
- add `engine/renderer` module with pygame logic
- extend game loop to support a pygame window when `steps=None`
- expose `Renderer` in `engine.__init__`
- demonstrate new visual window usage in `Test.py`

## Testing
- `python3 -m py_compile Test.py engine/__init__.py engine/world.py engine/entity.py engine/game.py engine/renderer.py`
- `SDL_VIDEODRIVER=dummy python3 Test.py` *(fails: KeyboardInterrupt because window can't open in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851dc97b7cc832084dad3a7c174b22d